### PR TITLE
added url as hostname+pagepath

### DIFF
--- a/src/filters/add-cluster-data.js
+++ b/src/filters/add-cluster-data.js
@@ -5,15 +5,16 @@ const addClusterData = (inputEvents, getIngressData) => {
     cloneEvent.platform = 'Web'; // Correct this back to the original.
     cloneEvent.event_properties = event.event_properties || {};
     const eventUrl = event.platform;
-    const eventUrlObj = new URL(eventUrl);
-    cloneEvent.event_properties.hostname = eventUrlObj.hostname;
-    cloneEvent.event_properties.pagePath = eventUrlObj.pathname;
     const ingressData = getIngressData(eventUrl);
     if (ingressData) {
       Object.keys(ingressData).forEach(key => {
         cloneEvent.event_properties[key] = ingressData[key];
       });
     }
+    const eventUrlObj = new URL(eventUrl);
+    cloneEvent.event_properties.url = eventUrlObj.hostname + eventUrlObj.pathname;
+    cloneEvent.event_properties.hostname = eventUrlObj.hostname;
+    cloneEvent.event_properties.pagePath = eventUrlObj.pathname;
     outputEvents.push(cloneEvent);
   });
   return outputEvents;


### PR DESCRIPTION
Added URL as an event property, consists of hostname and pagepath

Intended to help Amplitude users easily find traffic and usage data for a page, and analyse path navigation on our websites. 