### PR TITLE
block all crawlers from future indexing

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,2 @@
-User-Agent: *
+User-agent: *
+Disallow: /


### PR DESCRIPTION
This update to robots blocks all crawlers from indexing any pages on our subdomain for the future.

We are making this change now after we have successfully

- [x] removed the old index page and returned a 404, so search engines have removed it from their index

- [x] added a new index.html page with a valid robots noindex instruction in a meta tag

- [x] verified in google.com that there are no search results for the subdomain with the query `site:amplitude.nav.no`