### PR TITLE
La til header for caching av CORS preflight respons

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -47,7 +47,7 @@ module.exports = async (name) => {
   fastify.addSchema(require('./schemas/collect'));
   fastify.addSchema(require('./schemas/ingress'));
 
-  fastify.register(require('fastify-cors'), {origin: '*'});
+  fastify.register(require('fastify-cors'), {origin: '*', maxAge: 7200});
   fastify.register(require('fastify-formbody'));
   fastify.register(require('fastify-metrics'), {endpoint: paths.METRICS});
   fastify.register(require('fastify-static'), {root: path.join(__dirname, '..', 'public')});


### PR DESCRIPTION
La til caching av preflight i 2 timer (max verdi for Chrome v76 og nyere)
Se: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Max-Age