### PR TITLE
Benytter platform-felt fra event properties for å sette path/url

### DIFF
--- a/src/filters/add-cluster-data.js
+++ b/src/filters/add-cluster-data.js
@@ -5,7 +5,10 @@ const addClusterData = (inputEvents, getIngressData, ingresses) => {
     const cloneEvent = { ...event };
     cloneEvent.platform = 'Web'; // Correct this back to the original.
     cloneEvent.event_properties = event.event_properties || {};
-    let eventUrl = event.platform;
+
+    // Prefer the platform field from event properties, for correct url parsing
+    // from single-page apps
+    let eventUrl = cloneEvent.event_properties.platform || event.platform;
     if(eventUrl.includes('localhost')) {
       eventUrl = eventUrl.replace(/\:[0-9]+/g,'')
     }


### PR DESCRIPTION
`event.platform`-feltet settes når amplitude-klienten initialiseres. I single-page applications vil denne kun settes ved den initielle innlastingen av appen, og vil ikke oppdateres ved navigering. Feltene som settes på event_properties ut fra event.platform vil derfor ikke være korrekte i SPA'er etter første sidevisning (gjelder url, hostname og pagePath).

Denne PR'en muliggjør bruk av platform-felt fra event_properties, slik at appene kan sette denne uten å måtte re-initialisere amplitude-klienten.