### PR TITLE
Add body parser for text/plain -> JSON for beacon

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -57,6 +57,21 @@ module.exports = async (name) => {
     });
   }
 
+  // We parse text/plain as JSON, as the amplitude SDK does not set the content-type to json when
+  // using navigator.sendBeacon() to send events
+  fastify.addContentTypeParser(
+    "text/plain",
+    { parseAs: "string" },
+    (req, body, done) => {
+      try {
+        const json = JSON.parse(body);
+        done(null, json);
+      } catch (error) {
+        err.statusCode = 400;
+        done(err, undefined);
+      }
+    },
+  );
   fastify.addSchema(require('./schemas/collect'));
   fastify.addSchema(require('./schemas/ingress'));
 

--- a/test-utils/ensure-test-features.js
+++ b/test-utils/ensure-test-features.js
@@ -3,7 +3,7 @@
  */
 const fs = require('fs');
 const path = require('path');
-const setupTestEnvs = require('./setup-test-envs');
+const {TEST_NODE_ENV, TEST_PROJECT_KEY} = require('./constants');
 const logger = require('../src/utils/logger');
 
 const secretsPath = path.resolve(__dirname, '..', 'secrets', 'project-keys.json');
@@ -12,12 +12,8 @@ const secretsPath = path.resolve(__dirname, '..', 'secrets', 'project-keys.json'
  * Setting up test project keys
  */
 if (!fs.existsSync(secretsPath)) {
-  if (!process.env.TEST_PROJECT_KEY) {
-    logger.info('Need to set TEST_PROJECT_KEY in environment to create a project-keys file.');
-    process.exit(1);
-  }
   fs.writeFileSync(secretsPath, JSON.stringify({
-    [process.env.TEST_PROJECT_KEY]: '*',
+    [TEST_PROJECT_KEY]: '*',
   }));
   logger.info('Created a new project keys file.');
 } else {


### PR DESCRIPTION
When using the `beacon` transport mode in the amplitude SDK, it doesn't set the Content-Type header to `application/json`, and expects us to parse the body as JSON anyways. Supporting this in the proxy rather than opening a PR to amplitude is the easiest solution here.

With this change, we can use  the `beacon` transport mode and reliably track page exit events and make sure any queued events are sent successfully when the user closes the page or navigates away.
